### PR TITLE
Add missing const modifier to bounder_ptr()

### DIFF
--- a/src/jbms/array_view.hpp
+++ b/src/jbms/array_view.hpp
@@ -167,7 +167,7 @@ public:
   }
 
 private:
-  constexpr pointer bounded_ptr_(ptrdiff_t pos) {
+  constexpr pointer bounded_ptr_(ptrdiff_t pos) const {
     return begin() + std::min(ptrdiff_t(size()), std::max(pos, ptrdiff_t(0)));
   }
 public:


### PR DESCRIPTION
This is causing compile errors on modern compilers

`
../array_view/src/jbms/array_view.hpp:181:41: error: passing ‘const jbms::array_view<char>’ as ‘this’ argument discards qualifiers [-fpermissive]
     return { this->begin(), bounded_ptr_(pos) };
                             ~~~~~~~~~~~~^~~~~
`